### PR TITLE
Do not use faraday 2.x to fix dependency

### DIFF
--- a/bitrise-client.gemspec
+++ b/bitrise-client.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'faraday'
+  spec.add_runtime_dependency 'faraday', '~> 1'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "irb"


### PR DESCRIPTION
`Faraday::Response::Middleware` is deleted at https://github.com/lostisland/faraday/commit/08b7d4d3b75998ab347ee1ee614e8b29ef7b580a commit.
So I specify the last version of `Faraday::Response::Middleware` available one.